### PR TITLE
wip: rewrite neutrino installer

### DIFF
--- a/bin/install-neutrino
+++ b/bin/install-neutrino
@@ -3,14 +3,13 @@
 use strict;
 use warnings;
 
-use Getopt::Long qw( :config posix_default no_ignore_case bundling );
+our $VERSION = "v0.1.0";
 
 use Pod::Usage qw( pod2usage );
 use File::Temp qw( tempdir );
 
-my $prefix = $ENV{'NEUTRINO_PREFIX'} // $ENV{'HOME'} . '/.local/share/neutrino';
-
-my $VERSION = "v0.1.0";
+our $prefix = $ENV{'NEUTRINO_PREFIX'}
+  // $ENV{'HOME'} . '/.local/share/neutrino';
 
 sub which {
   my $cmd  = shift;
@@ -76,105 +75,150 @@ sub testing_unzip {
   }
 }
 
-sub install_neutrino {
-  my $zip    = shift;
-  my $tmpdir = tempdir( CLEANUP => 1 );
+sub is_neutrino {
+  my $dest = shift;
 
-  unzip( $zip, $tmpdir );
-
-  if ( !-e "${tmpdir}/NEUTRINO" ) {
-    print STDERR "this zip file is not NEUTRINO-Online.zip\n";
-    return !!0;
-  }
-
-  if ( !-e "${prefix}/dist" ) {
-    system( qw(mkdir -p), "${prefix}/dist" );
-  }
-
-  return system( qw(cp -R), "${tmpdir}/NEUTRINO/", "${prefix}/dist/" ) == 0;
-}
-
-sub install_model {
-  my $zip    = shift;
-  my $tmpdir = tempdir( CLEANUP => 1 );
-
-  unzip( $zip, $tmpdir );
-  if ( system(qq( bash -c 'ls "${tmpdir}"| grep NEUTRINO-Library' )) != 0 ) {
-    print STDERR "this zip file is not NEUTRINO Library zip\n";
-    return !!0;
-  }
-
-  if ( !-e "${prefix}/dist/NEUTRINO" ) {
-    print STDERR
-      "NEUTRINO does not installed yet. Please install NEUTRINO first.\n";
-    return !!0;
-  }
-
-  return
-    system(
-    qq( bash -c 'cp -R "${tmpdir}"/*/* "${prefix}"/dist/NEUTRINO/model/' )) ==
-    0;
-}
-
-sub main {
-  local @ARGV = @_;
-
-  if ( @ARGV == 0 ) {
-    pod2usage( -exitval => 1, -verbose => 1 );
-  }
-
-  my $neutrino;
-  my @models;
-
-  GetOptions(
-    "neutrino|n=s" => \$neutrino,
-    "model|m=s"    => \@models,
-    "version|v"    => sub {
-      print "install-neutrino - ${VERSION}", "\n";
-      exit 0;
-    },
-    "help|h" => sub {
-      pod2usage( -exitval => 0, -verbose => 1 );
-    },
-  ) or pod2usage( -exitval => 1, -verbose => 1 );
-
-  if ( !-d $prefix ) {
-    system( qw(mkdir -p), $prefix );
-  }
-
-  if ( $neutrino ne q{} ) {
-    local $@;
-    eval { install_neutrino($neutrino); };
-
-    if ($@) {
-      print STDERR "failed to install NEUTRINO from '${neutrino}': ${@}\n";
-      exit 1;
-    }
-
-    for my $bin (qw(NEUTRINO NSF WORLD musicXMLtoLabel)) {
-      local $!;
-      my $result =
-        system(qq(sh -c 'chmod +x "${prefix}/dist/NEUTRINO/bin/${bin}"'));
-      if ( $result != 0 ) {
-        print STDERR "failed to set executable flag to ${bin} file: ${$!}\n";
-        exit 1;
-      }
-    }
-  }
-
-  if ( @models > 0 ) {
-    for my $model (@models) {
-      local $@;
-      eval { install_model($model); };
-
-      if ($@) {
-        print STDERR "failed to install NEUTRINO model from '${model}': ${@}\n";
-        exit 1;
-      }
-    }
+  if ( -e "${dest}/NEUTRINO" ) {
+    return 1;
   }
 
   return 0;
+}
+
+sub testing_is_neutrino {
+  my $dest = tempdir( CLEANUP => 1 );
+  mkdir "${dest}/NEUTRINO";
+
+  ok( is_neutrino($dest) );
+}
+
+sub is_model {
+  my $bash = which("bash");
+  if ( !defined $bash || $bash eq q{} ) {
+    print STDERR "command not found: bash\n";
+    exit 1;
+  }
+
+  my $grep = which("grep");
+  if ( !defined $grep || $grep eq q{} ) {
+    print STDERR "command not found: grep";
+    exit 1;
+  }
+
+  my $dest   = shift;
+  my $result = system( $bash, '-c', "ls '${dest}' | ${grep} NEUTRINO-Library" );
+
+  return $result == 0;
+}
+
+sub testing_is_model {
+  my $dest = tempdir( CLEANUP => 1 );
+
+  mkdir "${dest}/---NEUTRINO-Library---";
+
+  ok( is_model($dest) );
+}
+
+sub is_zip {
+  my $file = which('file');
+  if ( !defined $file || $file eq q{} ) {
+    print STDERR "command is not found: file\n";
+    exit 1;
+  }
+
+  my $zip = shift;
+  return `"${file}" '${zip}'` =~ m{Zip archive data}s;
+}
+
+sub main {
+  my $bash = which("bash");
+  if ( !defined $bash || $bash eq q{} ) {
+    print STDERR "command not found: bash\n";
+    exit 1;
+  }
+
+  my $success = 0;
+
+  if ( !-e "${prefix}/dist/NEUTRINO/model" ) {
+    my $result = system( qw(mkdir -p), "${prefix}/dist/NEUTRINO/model" );
+    if ( $result != 0 ) {
+      print STDERR "faild to create install directory: ${prefix}/dist\n";
+      exit 1;
+    }
+  }
+
+  my @files = @_;
+  for my $file (@files) {
+    if ( !-e $file ) {
+      print STDERR "file is not found: ${file}\n";
+      next;
+    }
+
+    if ( !is_zip($file) ) {
+      print STDERR "file is not zip archive: ${file}\n";
+      next;
+    }
+
+    my $tmp = tempdir( CLEANUP => 1 );
+    unzip( $file, $tmp );
+
+    if ( is_neutrino($tmp) ) {
+      my $result =
+        system( qw(cp -R), "${tmp}/NEUTRINO/", "${prefix}/dist/" );
+
+      if ( $result != 0 ) {
+        print STDERR "failed to install NEUTRINO-Online to ${prefix}/dist\n";
+        next;
+      }
+
+      $success++;
+      print STDOUT "install NEUTRINO-Online successfully\n";
+      next;
+    }
+
+    if ( is_model($tmp) ) {
+      my $result = system(
+        qq<bash -c 'cp -R "${tmp}"/*/* "${prefix}"/dist/NEUTRINO/model/'>);
+
+      if ( $result != 0 ) {
+        print STDERR "failed to install NEUTRINO Model: ${file}\n";
+        next;
+      }
+
+      $success++;
+      print STDOUT "install NEUTRINO model successfully: ${file}\n";
+      next;
+    }
+
+    print STDERR
+      "this file does not contian NEUTRINO or model files: ${file}\n";
+  }
+
+  return $success > 0;
+}
+
+sub testing_main {
+  my $neutrino = $ENV{'TEST_NEUTRINO_ONLINE'};
+  my $model    = $ENV{'TEST_NEUTRINO_MODEL'};
+
+  my @argv;
+
+  if ( defined $neutrino && -e $neutrino ) {
+    push @argv, $neutrino;
+  }
+
+  if ( defined $model && -e $model ) {
+    push @argv, $model;
+  }
+
+  if ( @argv == 0 ) {
+    return;
+  }
+
+  local $prefix = tempdir( CLEANUP => 1 );
+  ok( main(@argv) );
+  ok( -e "${prefix}/dist/NEUTRINO" );
+  ok( -e "${prefix}/dist/NEUTRINO/model" );
 }
 
 sub testing {
@@ -184,11 +228,20 @@ sub testing {
     testing_which;
     testing_unzip;
 
+    testing_is_neutrino;
+    testing_is_model;
+
+    testing_main;
+
     done_testing;
   };
 }
 
-( !!$ENV{'HARNESS_ACTIVE'} ? testing(@ARGV) : main(@ARGV) );
+(
+  !!$ENV{'HARNESS_ACTIVE'}
+  ? testing(@ARGV)
+  : ( ( main(@ARGV) && exit 0 ) || exit 1 )
+);
 
 =encoding utf-8
 

--- a/bin/install-neutrino
+++ b/bin/install-neutrino
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-our $VERSION = "v0.1.0";
+our $VERSION = "v0.2.0";
 
 use Pod::Usage qw( pod2usage );
 use File::Temp qw( tempdir );
@@ -131,6 +131,19 @@ sub is_zip {
 }
 
 sub main {
+  if ( @_ == 0 ) {
+    pod2usage( -exitval => 0, -verbose => 2 );
+  }
+
+  if ( $_[0] eq '-h' || $_[0] eq '--help' ) {
+    pod2usage( -exitval => 0, verbose => 1 );
+  }
+
+  if ( $_[0] eq '-v' || $_[0] eq '--version' ) {
+    print STDOUT "install-neutrino - ${VERSION}\n";
+    exit 0;
+  }
+
   my $bash = which("bash");
   if ( !defined $bash || $bash eq q{} ) {
     print STDERR "command not found: bash\n";
@@ -163,8 +176,7 @@ sub main {
     unzip( $file, $tmp );
 
     if ( is_neutrino($tmp) ) {
-      my $result =
-        system( qw(cp -R), "${tmp}/NEUTRINO/", "${prefix}/dist/" );
+      my $result = system( qw(cp -R), "${tmp}/NEUTRINO/", "${prefix}/dist/" );
 
       if ( $result != 0 ) {
         print STDERR "failed to install NEUTRINO-Online to ${prefix}/dist\n";
@@ -250,22 +262,12 @@ sub testing {
 install-neutrino - Installer script for NEUTRINO AI Singing Synthizer.
 
 =head1 USAGE
+ 
+  $ install-neutrino ~/Downloads/NEUTRINO-Online-v1.1.0.zip ~/Downloads/"No.7（NEUTRINO-Library）.zip" ...
 
-  # install NEUTRINO
-  $ install-neutrino -n ~/Downloads/NEUTRINO-Online.zip
+=head1 SUPPORTED VERSION
 
-  # install NEUTRINO models
-  $ install-neutrino -m ~/Downloads/"No.7（NEUTRINO-Library）.zip"
-
-=head1 OPTIONS
-
-=head2 -n or --neutrino
-
-Install NEUTRINO VI Singing Synthizer from local zip file.
-
-=head2 -m or --model
-
-Install NEUTRINO Models from local zip file.
+NEUTRINO v1.1.0
 
 =head1 SEE ALSO
 

--- a/bin/install-neutrino
+++ b/bin/install-neutrino
@@ -12,6 +12,26 @@ my $prefix = $ENV{'NEUTRINO_PREFIX'} // $ENV{'HOME'} . '/.local/share/neutrino';
 
 my $VERSION = "v0.1.0";
 
+sub which {
+  my $cmd = shift;
+  my $path = `which '${cmd}'`;
+
+  chomp($path);
+
+  return undef if ($path eq q{});
+  return $path;
+}
+
+sub testing_which {
+  my $cmd = which('which');
+
+  like( $cmd, qr{/which$} );
+
+  $cmd = which('');
+
+  is($cmd, undef);
+}
+
 sub unzip {
     my $zip  = shift;
     my $dest = shift;
@@ -122,7 +142,17 @@ sub main {
     return 0;
 }
 
-main(@ARGV);
+sub testing {
+  eval {
+    use Test::More;
+
+    testing_which;
+
+    done_testing;
+  };
+}
+
+(!! $ENV{'HARNESS_ACTIVE'} ? testing(@ARGV) : main(@ARGV));
 
 =encoding utf-8
 

--- a/bin/install-neutrino
+++ b/bin/install-neutrino
@@ -13,12 +13,12 @@ my $prefix = $ENV{'NEUTRINO_PREFIX'} // $ENV{'HOME'} . '/.local/share/neutrino';
 my $VERSION = "v0.1.0";
 
 sub which {
-  my $cmd = shift;
+  my $cmd  = shift;
   my $path = `which '${cmd}'`;
 
   chomp($path);
 
-  return undef if ($path eq q{});
+  return undef if ( $path eq q{} );
   return $path;
 }
 
@@ -29,18 +29,51 @@ sub testing_which {
 
   $cmd = which('');
 
-  is($cmd, undef);
+  is( $cmd, undef );
 }
 
 sub unzip {
+  my $unzip = which('unzip');
+  if ( !defined $unzip || $unzip eq q{} ) {
+    print STDERR "command is not found: unzip\n";
+    exit 1;
+  }
+
+  my $file = which('file');
+  if ( !defined $file || $file eq q{} ) {
+    print STDERR "command is not found: file\n";
+    exit 1;
+  }
+
   my $zip  = shift;
   my $dest = shift;
 
   if ( !-e $zip ) {
-    die "zip file does not found: ${zip}";
+    print STDERR "file does not exists: ${zip}\n";
+    exit 1;
   }
 
-  system( qw(unzip -d), $dest, $zip ) == 0;
+  if ( `"${file}" '${zip}'` !~ m{Zip archive data}s ) {
+    print STDERR "this file is not zip archive: ${zip}\n";
+    exit 1;
+  }
+
+  my $result = system( $unzip, '-d', $dest, $zip );
+  if ( $result != 0 ) {
+    print STDERR "failed to unzip file: ${dest}: ${zip}\n";
+  }
+
+  return 1;
+}
+
+sub testing_unzip {
+  my $zip = $ENV{'TEST_NEUTRINO_ONLINE'};
+  if ( defined $zip && -e $zip ) {
+    my $dest = tempdir( CLEANUP => 1 );
+    ok( unzip( $zip, $dest ) );
+
+    ok( -e "${dest}/NEUTRINO" );
+  }
 }
 
 sub install_neutrino {
@@ -149,12 +182,13 @@ sub testing {
     use Test::More;
 
     testing_which;
+    testing_unzip;
 
     done_testing;
   };
 }
 
-(!! $ENV{'HARNESS_ACTIVE'} ? testing(@ARGV) : main(@ARGV));
+( !!$ENV{'HARNESS_ACTIVE'} ? testing(@ARGV) : main(@ARGV) );
 
 =encoding utf-8
 


### PR DESCRIPTION
**What's your pull request improve our codebase.**

This pull request make simplified to install NEUTRINO related zip files.

At the moment, `install-neutrino` requires argument flags to install NEUTRINO-Online or NEUTRINO models,
but this patch remove these flags, and auto detect zip file is NEUTRINO-Online or NEUTRINO models.

**Sign**

- [x] I agreed to [Code of Conduct](https://github.com/nyarla/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I agreed to [Support policy](https://github.com/nyarla/.github/blob/main/SUPPORT.md)
- [x] I agreed to [Contributors Licenses Agreements](https://github.com/nyarla/.github/blob/main/CLAs.md)
